### PR TITLE
update base url to reference `api.covidcast.cmu.edu/epidata`

### DIFF
--- a/epidatpy/_constants.py
+++ b/epidatpy/_constants.py
@@ -6,4 +6,4 @@ __version__: Final = "1.0.0"
 
 HTTP_HEADERS: Final = {"User-Agent": f"epidatpy/{__version__}"}
 
-BASE_URL: Final = "https://delphi.cmu.edu/epidata/"
+BASE_URL: Final = "https://api.covidcast.cmu.edu/epidata/"


### PR DESCRIPTION
see https://github.com/cmu-delphi/delphi-epidata/pull/1164