### PR TITLE
update base url to `api.delphi.cmu.edu`

### DIFF
--- a/epidatpy/_constants.py
+++ b/epidatpy/_constants.py
@@ -6,4 +6,4 @@ __version__: Final = "1.0.0"
 
 HTTP_HEADERS: Final = {"User-Agent": f"epidatpy/{__version__}"}
 
-BASE_URL: Final = "https://api.covidcast.cmu.edu/epidata/"
+BASE_URL: Final = "https://api.delphi.cmu.edu/epidata/"


### PR DESCRIPTION
follow-up to #20 

approvals are very welcome, but this should not be merged until we have a new cert installed for `api.delphi.cmu.edu`. (PR is in draft status to prevent accidental merging.)